### PR TITLE
feat(barcode-reader): config schema, validation, and Configure hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,21 @@
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./esm/index.d.ts",
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
+    "./barcode-reader/config": {
+      "types": "./esm/barcode-reader/config.d.ts",
+      "import": "./esm/barcode-reader/config.js",
+      "require": "./cjs/barcode-reader/config.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "scripts": {
     "build": "tsc && tsc -m esnext --outDir ./esm -d",
     "test": "node --test --require ts-node/register \"src/**/*.test.ts\""

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "module": "esm/index.js",
   "types": "esm/index.d.ts",
   "scripts": {
-    "build": "tsc && tsc -m esnext --outDir ./esm -d"
+    "build": "tsc && tsc -m esnext --outDir ./esm -d",
+    "test": "node --test --require ts-node/register \"src/**/*.test.ts\""
   },
   "author": "Variocube",
   "license": "ISC",
@@ -27,7 +28,8 @@
   "files": [
     "cjs/**/*",
     "esm/**/*",
-    "src/**/*"
+    "src/**/*",
+    "!src/**/*.test.ts"
   ],
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "module": "esm/index.js",
   "types": "esm/index.d.ts",
   "scripts": {
-    "build": "tsc && tsc -m esnext --outDir ./esm -d",
-    "local-build": "npm run build && npm pack variocube-driver-common-2.0.6.tgz"
+    "build": "tsc && tsc -m esnext --outDir ./esm -d"
   },
   "author": "Variocube",
   "license": "ISC",

--- a/src/barcode-reader/config.test.ts
+++ b/src/barcode-reader/config.test.ts
@@ -94,6 +94,13 @@ const cases: Case[] = [
     {name: "suffix too long", config: {outputFormatting: {suffix: "x".repeat(65)}}, valid: false},
     {name: "groupSeparator too long", config: {outputFormatting: {groupSeparator: "x".repeat(17)}}, valid: false},
     {name: "interCharacterDelay above ceiling", config: {outputFormatting: {interCharacterDelayMs: 60_001}}, valid: false},
+
+    // Prefix/suffix must not contain the active terminator sequence (frames early)
+    {name: "prefix contains LF terminator", config: {outputFormatting: {terminator: "LF", prefix: "a\nb"}}, valid: false},
+    {name: "suffix contains CR terminator", config: {outputFormatting: {terminator: "CR", suffix: "x\r"}}, valid: false},
+    {name: "prefix contains CRLF terminator", config: {outputFormatting: {terminator: "CRLF", prefix: "a\r\nb"}}, valid: false},
+    {name: "prefix with LF but terminator none", config: {outputFormatting: {terminator: "none", prefix: "a\nb"}}, valid: true},
+    {name: "prefix with LF but terminator CR (different byte)", config: {outputFormatting: {terminator: "CR", prefix: "a\nb"}}, valid: true},
 ];
 
 for (const c of cases) {

--- a/src/barcode-reader/config.test.ts
+++ b/src/barcode-reader/config.test.ts
@@ -1,0 +1,117 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {BarcodeReaderConfig, Symbology, validateBarcodeConfig} from "./config";
+
+interface Case {
+    name: string;
+    config: BarcodeReaderConfig;
+    valid: boolean;
+}
+
+const cases: Case[] = [
+    // Valid
+    {name: "empty config", config: {}, valid: true},
+    {
+        name: "full well-formed config",
+        config: {
+            symbologies: {[Symbology.EAN13]: true, [Symbology.QR]: false},
+            indicators: {
+                led: {enabled: true, brightness: 80},
+                beeper: {enabled: false, volume: 50},
+                successTone: {frequencyHz: 2000, durationMs: 100},
+                errorTone: {frequencyHz: 500, durationMs: 200},
+            },
+            triggerTiming: {
+                illuminationTimeoutMs: 1000,
+                idleToSleepMs: 30000,
+                scanTimeoutMs: 5000,
+                duplicateSuppressionMs: 500,
+            },
+            outputFormatting: {
+                prefix: ">",
+                suffix: "<",
+                terminator: "CRLF",
+                interCharacterDelayMs: 10,
+                groupSeparator: "|",
+            },
+        },
+        valid: true,
+    },
+    {name: "boundary values at limits", config: {
+        indicators: {led: {brightness: 0}, beeper: {volume: 100}, successTone: {frequencyHz: 20000, durationMs: 0}},
+        triggerTiming: {scanTimeoutMs: 3_600_000},
+        outputFormatting: {interCharacterDelayMs: 60_000, prefix: "x".repeat(64), groupSeparator: "y".repeat(16)},
+    }, valid: true},
+    // Forward-compat: unknown fields ignored
+    {name: "unknown top-level field ignored", config: ({foo: "bar"} as unknown) as BarcodeReaderConfig, valid: true},
+    {
+        name: "unknown nested field ignored",
+        config: ({outputFormatting: {prefix: "p", extra: 1}} as unknown) as BarcodeReaderConfig,
+        valid: true,
+    },
+
+    // Symbologies
+    {
+        name: "non-boolean symbology value",
+        config: ({symbologies: {[Symbology.EAN13]: "yes"}} as unknown) as BarcodeReaderConfig,
+        valid: false,
+    },
+
+    // Indicators: enabled must be boolean
+    {
+        name: "led.enabled non-boolean",
+        config: ({indicators: {led: {enabled: 1}}} as unknown) as BarcodeReaderConfig,
+        valid: false,
+    },
+    {
+        name: "beeper.enabled non-boolean",
+        config: ({indicators: {beeper: {enabled: "on"}}} as unknown) as BarcodeReaderConfig,
+        valid: false,
+    },
+
+    // Percent bounds
+    {name: "brightness below 0", config: {indicators: {led: {brightness: -1}}}, valid: false},
+    {name: "brightness above 100", config: {indicators: {led: {brightness: 101}}}, valid: false},
+    {name: "volume above 100", config: {indicators: {beeper: {volume: 200}}}, valid: false},
+    {name: "brightness NaN", config: {indicators: {led: {brightness: NaN}}}, valid: false},
+    {name: "volume Infinity", config: {indicators: {beeper: {volume: Infinity}}}, valid: false},
+
+    // Tones
+    {name: "tone frequency above ceiling", config: {indicators: {successTone: {frequencyHz: 20001}}}, valid: false},
+    {name: "tone duration negative", config: {indicators: {errorTone: {durationMs: -5}}}, valid: false},
+
+    // Trigger timing
+    {name: "timeout negative", config: {triggerTiming: {scanTimeoutMs: -1}}, valid: false},
+    {name: "timeout above ceiling", config: {triggerTiming: {idleToSleepMs: 3_600_001}}, valid: false},
+
+    // Output formatting
+    {
+        name: "bad terminator",
+        config: ({outputFormatting: {terminator: "NL"}} as unknown) as BarcodeReaderConfig,
+        valid: false,
+    },
+    {name: "prefix too long", config: {outputFormatting: {prefix: "x".repeat(65)}}, valid: false},
+    {name: "suffix too long", config: {outputFormatting: {suffix: "x".repeat(65)}}, valid: false},
+    {name: "groupSeparator too long", config: {outputFormatting: {groupSeparator: "x".repeat(17)}}, valid: false},
+    {name: "interCharacterDelay above ceiling", config: {outputFormatting: {interCharacterDelayMs: 60_001}}, valid: false},
+];
+
+for (const c of cases) {
+    test(c.name, () => {
+        const result = validateBarcodeConfig(c.config);
+        assert.equal(result.valid, c.valid, JSON.stringify(result.errors));
+        // errors[] is non-empty exactly when invalid
+        assert.equal(result.errors.length > 0, !c.valid);
+    });
+}
+
+test("each valid terminator passes", () => {
+    for (const terminator of ["CR", "LF", "CRLF", "none"] as const) {
+        assert.equal(validateBarcodeConfig({outputFormatting: {terminator}}).valid, true);
+    }
+});
+
+test("null config is invalid, not thrown", () => {
+    const result = validateBarcodeConfig((null as unknown) as BarcodeReaderConfig);
+    assert.equal(result.valid, false);
+});

--- a/src/barcode-reader/config.ts
+++ b/src/barcode-reader/config.ts
@@ -42,6 +42,11 @@ export interface ToneConfig {
 
 /**
  * Visual and audible feedback indicators.
+ *
+ * Note: `brightness` and `volume` are standardized to a 0–100 percentage in this
+ * schema. Physical readers may use other scales (e.g. 0–255 or discrete levels);
+ * since this schema is device-agnostic and we do not assume any vendor's units,
+ * the driver is responsible for mapping the percentage onto the device's scale.
  */
 export interface IndicatorConfig {
     /** Scan indicator LED. */
@@ -147,6 +152,11 @@ const VALID_TERMINATORS: ReadonlyArray<OutputTerminator> = ["CR", "LF", "CRLF", 
 const MAX_PREFIX_SUFFIX_LENGTH = 64;
 const MAX_GROUP_SEPARATOR_LENGTH = 16;
 
+/** Sanity ceilings — not vendor limits, just to catch fat-finger / nonsensical values. */
+const MAX_TIMEOUT_MS = 3_600_000; // 1 hour
+const MAX_INTER_CHARACTER_DELAY_MS = 60_000; // 1 minute
+const MAX_FREQUENCY_HZ = 20_000; // upper edge of human hearing
+
 /**
  * Validates a {@link BarcodeReaderConfig} against the v1 schema.
  *
@@ -175,7 +185,7 @@ export function validateBarcodeConfig(config: BarcodeReaderConfig): ValidationRe
         }
     };
 
-    const checkNonNegative = (value: unknown, path: string) => {
+    const checkNonNegative = (value: unknown, path: string, max?: number) => {
         if (value === undefined) {
             return;
         }
@@ -183,6 +193,17 @@ export function validateBarcodeConfig(config: BarcodeReaderConfig): ValidationRe
             errors.push(`${path} must be a number`);
         } else if (value < 0) {
             errors.push(`${path} must be non-negative`);
+        } else if (max !== undefined && value > max) {
+            errors.push(`${path} must be at most ${max}`);
+        }
+    };
+
+    const checkBoolean = (value: unknown, path: string) => {
+        if (value === undefined) {
+            return;
+        }
+        if (typeof value !== "boolean") {
+            errors.push(`${path} must be a boolean`);
         }
     };
 
@@ -212,29 +233,31 @@ export function validateBarcodeConfig(config: BarcodeReaderConfig): ValidationRe
     }
 
     if (indicators !== undefined) {
+        checkBoolean(indicators.led?.enabled, "indicators.led.enabled");
+        checkBoolean(indicators.beeper?.enabled, "indicators.beeper.enabled");
         checkPercent(indicators.led?.brightness, "indicators.led.brightness");
         checkPercent(indicators.beeper?.volume, "indicators.beeper.volume");
         for (const tone of [["successTone", indicators.successTone] as const, ["errorTone", indicators.errorTone] as const]) {
             const [name, value] = tone;
             if (value !== undefined) {
-                checkNonNegative(value.frequencyHz, `indicators.${name}.frequencyHz`);
-                checkNonNegative(value.durationMs, `indicators.${name}.durationMs`);
+                checkNonNegative(value.frequencyHz, `indicators.${name}.frequencyHz`, MAX_FREQUENCY_HZ);
+                checkNonNegative(value.durationMs, `indicators.${name}.durationMs`, MAX_TIMEOUT_MS);
             }
         }
     }
 
     if (triggerTiming !== undefined) {
-        checkNonNegative(triggerTiming.illuminationTimeoutMs, "triggerTiming.illuminationTimeoutMs");
-        checkNonNegative(triggerTiming.idleToSleepMs, "triggerTiming.idleToSleepMs");
-        checkNonNegative(triggerTiming.scanTimeoutMs, "triggerTiming.scanTimeoutMs");
-        checkNonNegative(triggerTiming.duplicateSuppressionMs, "triggerTiming.duplicateSuppressionMs");
+        checkNonNegative(triggerTiming.illuminationTimeoutMs, "triggerTiming.illuminationTimeoutMs", MAX_TIMEOUT_MS);
+        checkNonNegative(triggerTiming.idleToSleepMs, "triggerTiming.idleToSleepMs", MAX_TIMEOUT_MS);
+        checkNonNegative(triggerTiming.scanTimeoutMs, "triggerTiming.scanTimeoutMs", MAX_TIMEOUT_MS);
+        checkNonNegative(triggerTiming.duplicateSuppressionMs, "triggerTiming.duplicateSuppressionMs", MAX_TIMEOUT_MS);
     }
 
     if (outputFormatting !== undefined) {
         checkString(outputFormatting.prefix, "outputFormatting.prefix", MAX_PREFIX_SUFFIX_LENGTH);
         checkString(outputFormatting.suffix, "outputFormatting.suffix", MAX_PREFIX_SUFFIX_LENGTH);
         checkString(outputFormatting.groupSeparator, "outputFormatting.groupSeparator", MAX_GROUP_SEPARATOR_LENGTH);
-        checkNonNegative(outputFormatting.interCharacterDelayMs, "outputFormatting.interCharacterDelayMs");
+        checkNonNegative(outputFormatting.interCharacterDelayMs, "outputFormatting.interCharacterDelayMs", MAX_INTER_CHARACTER_DELAY_MS);
         if (
             outputFormatting.terminator !== undefined
             && !VALID_TERMINATORS.includes(outputFormatting.terminator)

--- a/src/barcode-reader/config.ts
+++ b/src/barcode-reader/config.ts
@@ -1,0 +1,247 @@
+/**
+ * Standardized v1 configuration schema for barcode reader drivers.
+ *
+ * The controller sends a (possibly partial) {@link BarcodeReaderConfig} to a driver.
+ * The driver overlays the received config on its own vendor default profile and
+ * translates it into vendor-specific commands. Any unsupported property is silently
+ * skipped at apply time, so this schema stays forward-compatible: adding fields here
+ * never breaks an older driver.
+ *
+ * All groups are optional. A controller may send any subset.
+ */
+
+/**
+ * Barcode symbologies (code types) a reader may support.
+ *
+ * This is an open v1 subset; readers may support additional symbologies not listed
+ * here. Drivers skip symbologies they do not recognize.
+ */
+export enum Symbology {
+    EAN13 = "EAN13",
+    EAN8 = "EAN8",
+    UPCA = "UPCA",
+    UPCE = "UPCE",
+    Code128 = "Code128",
+    Code39 = "Code39",
+    QR = "QR",
+    DataMatrix = "DataMatrix",
+    PDF417 = "PDF417",
+    Aztec = "Aztec",
+}
+
+/**
+ * Configuration for an audible feedback tone.
+ */
+export interface ToneConfig {
+    /** Tone frequency in Hertz. Typical range 1000–4000. */
+    frequencyHz?: number;
+
+    /** Tone duration in milliseconds. Non-negative. */
+    durationMs?: number;
+}
+
+/**
+ * Visual and audible feedback indicators.
+ */
+export interface IndicatorConfig {
+    /** Scan indicator LED. */
+    led?: {
+        /** Whether the LED is enabled. */
+        enabled?: boolean;
+
+        /** LED brightness as a percentage, 0–100. */
+        brightness?: number;
+    };
+
+    /** Scan beeper. */
+    beeper?: {
+        /** Whether the beeper is enabled. */
+        enabled?: boolean;
+
+        /** Beeper volume as a percentage, 0–100. */
+        volume?: number;
+    };
+
+    /** Tone played on a successful scan. */
+    successTone?: ToneConfig;
+
+    /** Tone played on a failed/error scan. */
+    errorTone?: ToneConfig;
+}
+
+/**
+ * Trigger timing parameters.
+ *
+ * Note: trigger mode (e.g. manual/continuous/presentation) is explicitly out of
+ * scope for v1 — there is no command for it yet, so no `mode` field exists here.
+ */
+export interface TriggerTimingConfig {
+    /** How long illumination stays on while attempting a scan, in milliseconds. Non-negative. */
+    illuminationTimeoutMs?: number;
+
+    /** Idle time before the reader enters sleep, in milliseconds. Non-negative. */
+    idleToSleepMs?: number;
+
+    /** Maximum time to attempt a single scan before giving up, in milliseconds. Non-negative. */
+    scanTimeoutMs?: number;
+
+    /** Window during which an identical re-scan is suppressed, in milliseconds. Non-negative. */
+    duplicateSuppressionMs?: number;
+}
+
+/**
+ * Line terminator appended after the decoded data (and suffix).
+ */
+export type OutputTerminator = "CR" | "LF" | "CRLF" | "none";
+
+/**
+ * Output formatting applied to the decoded barcode data before it is emitted.
+ */
+export interface OutputFormattingConfig {
+    /** String prepended to the decoded data. Max 64 characters. */
+    prefix?: string;
+
+    /** String appended to the decoded data (before the terminator). Max 64 characters. */
+    suffix?: string;
+
+    /** Line terminator appended after the data. */
+    terminator?: OutputTerminator;
+
+    /** Delay between emitted characters, in milliseconds. Non-negative. */
+    interCharacterDelayMs?: number;
+
+    /** Separator inserted between grouped data segments. Max 16 characters. */
+    groupSeparator?: string;
+}
+
+/**
+ * Standardized v1 barcode reader configuration. All groups are optional; a
+ * controller may send any subset and the driver overlays it on its default profile.
+ */
+export interface BarcodeReaderConfig {
+    /** Enable/disable decoding per symbology. */
+    symbologies?: Partial<Record<Symbology, boolean>>;
+
+    /** Visual and audible feedback indicators. */
+    indicators?: IndicatorConfig;
+
+    /** Trigger timing parameters. */
+    triggerTiming?: TriggerTimingConfig;
+
+    /** Output formatting applied to decoded data. */
+    outputFormatting?: OutputFormattingConfig;
+}
+
+/**
+ * Result of validating a {@link BarcodeReaderConfig}.
+ */
+export interface ValidationResult {
+    /** Whether the config passed validation. */
+    valid: boolean;
+
+    /** Human-readable validation errors. Empty when {@link valid} is `true`. */
+    errors: string[];
+}
+
+const VALID_TERMINATORS: ReadonlyArray<OutputTerminator> = ["CR", "LF", "CRLF", "none"];
+const MAX_PREFIX_SUFFIX_LENGTH = 64;
+const MAX_GROUP_SEPARATOR_LENGTH = 16;
+
+/**
+ * Validates a {@link BarcodeReaderConfig} against the v1 schema.
+ *
+ * Pure, dependency-free, and never throws. This is the single source of truth used
+ * by both the SDK (pre-send, for fast developer feedback) and the driver (on-receive,
+ * as defense in depth).
+ *
+ * Unknown/extra fields are intentionally ignored (forward-compatibility) — they do
+ * not cause validation to fail.
+ */
+export function validateBarcodeConfig(config: BarcodeReaderConfig): ValidationResult {
+    const errors: string[] = [];
+
+    if (config === null || typeof config !== "object") {
+        return {valid: false, errors: ["config must be an object"]};
+    }
+
+    const checkPercent = (value: unknown, path: string) => {
+        if (value === undefined) {
+            return;
+        }
+        if (typeof value !== "number" || !isFinite(value)) {
+            errors.push(`${path} must be a number`);
+        } else if (value < 0 || value > 100) {
+            errors.push(`${path} must be between 0 and 100`);
+        }
+    };
+
+    const checkNonNegative = (value: unknown, path: string) => {
+        if (value === undefined) {
+            return;
+        }
+        if (typeof value !== "number" || !isFinite(value)) {
+            errors.push(`${path} must be a number`);
+        } else if (value < 0) {
+            errors.push(`${path} must be non-negative`);
+        }
+    };
+
+    const checkString = (value: unknown, path: string, maxLength: number) => {
+        if (value === undefined) {
+            return;
+        }
+        if (typeof value !== "string") {
+            errors.push(`${path} must be a string`);
+        } else if (value.length > maxLength) {
+            errors.push(`${path} must be at most ${maxLength} characters`);
+        }
+    };
+
+    const {symbologies, indicators, triggerTiming, outputFormatting} = config;
+
+    if (symbologies !== undefined) {
+        if (typeof symbologies !== "object" || symbologies === null) {
+            errors.push("symbologies must be an object");
+        } else {
+            for (const [key, value] of Object.entries(symbologies)) {
+                if (typeof value !== "boolean") {
+                    errors.push(`symbologies.${key} must be a boolean`);
+                }
+            }
+        }
+    }
+
+    if (indicators !== undefined) {
+        checkPercent(indicators.led?.brightness, "indicators.led.brightness");
+        checkPercent(indicators.beeper?.volume, "indicators.beeper.volume");
+        for (const tone of [["successTone", indicators.successTone] as const, ["errorTone", indicators.errorTone] as const]) {
+            const [name, value] = tone;
+            if (value !== undefined) {
+                checkNonNegative(value.frequencyHz, `indicators.${name}.frequencyHz`);
+                checkNonNegative(value.durationMs, `indicators.${name}.durationMs`);
+            }
+        }
+    }
+
+    if (triggerTiming !== undefined) {
+        checkNonNegative(triggerTiming.illuminationTimeoutMs, "triggerTiming.illuminationTimeoutMs");
+        checkNonNegative(triggerTiming.idleToSleepMs, "triggerTiming.idleToSleepMs");
+        checkNonNegative(triggerTiming.scanTimeoutMs, "triggerTiming.scanTimeoutMs");
+        checkNonNegative(triggerTiming.duplicateSuppressionMs, "triggerTiming.duplicateSuppressionMs");
+    }
+
+    if (outputFormatting !== undefined) {
+        checkString(outputFormatting.prefix, "outputFormatting.prefix", MAX_PREFIX_SUFFIX_LENGTH);
+        checkString(outputFormatting.suffix, "outputFormatting.suffix", MAX_PREFIX_SUFFIX_LENGTH);
+        checkString(outputFormatting.groupSeparator, "outputFormatting.groupSeparator", MAX_GROUP_SEPARATOR_LENGTH);
+        checkNonNegative(outputFormatting.interCharacterDelayMs, "outputFormatting.interCharacterDelayMs");
+        if (
+            outputFormatting.terminator !== undefined
+            && !VALID_TERMINATORS.includes(outputFormatting.terminator)
+        ) {
+            errors.push(`outputFormatting.terminator must be one of ${VALID_TERMINATORS.join(", ")}`);
+        }
+    }
+
+    return {valid: errors.length === 0, errors};
+}

--- a/src/barcode-reader/config.ts
+++ b/src/barcode-reader/config.ts
@@ -96,17 +96,33 @@ export interface TriggerTimingConfig {
 
 /**
  * Line terminator appended after the decoded data (and suffix).
+ *
+ * Consumed by the driver as the scan FRAMING delimiter: it marks end-of-scan,
+ * is stripped, and is never forwarded to the app. It is therefore a small, closed
+ * set on purpose — the read path must recognise and strip this exact sequence, so
+ * every added value is a new framing case. The decoded payload (and any prefix/
+ * suffix) MUST NOT contain the active terminator, or the scan frames early.
+ *
+ * "none" disables the in-band terminator; the driver then frames by idle-timeout
+ * (flush on serial silence). This is the supported path for arbitrary BINARY
+ * payloads, where no in-band delimiter is safe. See variocube/drivers#16.
  */
 export type OutputTerminator = "CR" | "LF" | "CRLF" | "none";
 
 /**
  * Output formatting applied to the decoded barcode data before it is emitted.
+ *
+ * prefix and suffix are content decoration: the reader adds them and the driver
+ * passes them THROUGH to the app unchanged (they are not stripped — stripping
+ * them would make configuring them pointless). Only the terminator is consumed by
+ * the driver (see OutputTerminator). Because the terminator is the frame delimiter,
+ * prefix and suffix must not contain the active terminator sequence.
  */
 export interface OutputFormattingConfig {
-    /** String prepended to the decoded data. Max 64 characters. */
+    /** String prepended to the decoded data and forwarded to the app. Max 64 chars. Must not contain the terminator sequence. */
     prefix?: string;
 
-    /** String appended to the decoded data (before the terminator). Max 64 characters. */
+    /** String appended to the decoded data (before the terminator) and forwarded to the app. Max 64 chars. Must not contain the terminator sequence. */
     suffix?: string;
 
     /** Line terminator appended after the data. */
@@ -151,6 +167,13 @@ export interface ValidationResult {
 const VALID_TERMINATORS: ReadonlyArray<OutputTerminator> = ["CR", "LF", "CRLF", "none"];
 const MAX_PREFIX_SUFFIX_LENGTH = 64;
 const MAX_GROUP_SEPARATOR_LENGTH = 16;
+
+/** Byte sequences each terminator maps to on the wire. `none` has no in-band bytes. */
+const TERMINATOR_BYTES: Record<Exclude<OutputTerminator, "none">, string> = {
+    CR: "\r",
+    LF: "\n",
+    CRLF: "\r\n",
+};
 
 /** Sanity ceilings — not vendor limits, just to catch fat-finger / nonsensical values. */
 const MAX_TIMEOUT_MS = 3_600_000; // 1 hour
@@ -258,11 +281,18 @@ export function validateBarcodeConfig(config: BarcodeReaderConfig): ValidationRe
         checkString(outputFormatting.suffix, "outputFormatting.suffix", MAX_PREFIX_SUFFIX_LENGTH);
         checkString(outputFormatting.groupSeparator, "outputFormatting.groupSeparator", MAX_GROUP_SEPARATOR_LENGTH);
         checkNonNegative(outputFormatting.interCharacterDelayMs, "outputFormatting.interCharacterDelayMs", MAX_INTER_CHARACTER_DELAY_MS);
-        if (
-            outputFormatting.terminator !== undefined
-            && !VALID_TERMINATORS.includes(outputFormatting.terminator)
-        ) {
+        const {terminator, prefix, suffix} = outputFormatting;
+        if (terminator !== undefined && !VALID_TERMINATORS.includes(terminator)) {
             errors.push(`outputFormatting.terminator must be one of ${VALID_TERMINATORS.join(", ")}`);
+        } else if (terminator !== undefined && terminator !== "none") {
+            // The terminator is the frame delimiter; if prefix/suffix carry it, the scan frames early.
+            const bytes = TERMINATOR_BYTES[terminator];
+            if (typeof prefix === "string" && prefix.includes(bytes)) {
+                errors.push(`outputFormatting.prefix must not contain the ${terminator} terminator sequence`);
+            }
+            if (typeof suffix === "string" && suffix.includes(bytes)) {
+                errors.push(`outputFormatting.suffix must not contain the ${terminator} terminator sequence`);
+            }
         }
     }
 

--- a/src/barcode-reader/driver.ts
+++ b/src/barcode-reader/driver.ts
@@ -1,10 +1,14 @@
-import {BarcodeReaderMessageTypes, BarcodeScanned} from "./messages";
+import {BarcodeReaderMessageTypes, BarcodeScanned, ConfigureBarcodeReader} from "./messages";
 import {ClientOptions, Driver, DriverType} from "../common";
 
 export class BarcodeReaderDriver extends Driver {
 
     constructor(options?: ClientOptions) {
         super(DriverType.BarcodeReader, options);
+    }
+
+    set onConfigure(handler: (message: ConfigureBarcodeReader) => Promise<void>) {
+        this.client.on(BarcodeReaderMessageTypes.Configure, handler);
     }
 
     async sendBarcodeScanned(code: string, unit: string) {

--- a/src/barcode-reader/index.ts
+++ b/src/barcode-reader/index.ts
@@ -1,2 +1,3 @@
+export * from "./config";
 export * from "./messages";
 export * from "./driver";

--- a/src/barcode-reader/messages.ts
+++ b/src/barcode-reader/messages.ts
@@ -5,8 +5,11 @@
  * and send a message when a barcode is successfully scanned.
  */
 
+import {BarcodeReaderConfig} from "./config";
+
 export enum BarcodeReaderMessageTypes {
     BarcodeScanned = "barcode-reader:BarcodeScanned",
+    Configure = "barcode-reader:Configure",
 }
 
 export interface BarcodeScanned {
@@ -19,5 +22,18 @@ export interface BarcodeScanned {
     unit: string;
 }
 
+/**
+ * Sent to a barcode reader driver to (re)configure the reader.
+ *
+ * The config may be partial; the driver overlays it on its default vendor profile.
+ */
+export interface ConfigureBarcodeReader {
+    "@type": BarcodeReaderMessageTypes.Configure;
+
+    /** The standardized barcode reader configuration to apply. */
+    config: BarcodeReaderConfig;
+}
+
 export type BarcodeReaderMessage =
-    BarcodeScanned;
+    BarcodeScanned
+    | ConfigureBarcodeReader;

--- a/src/barcode-reader/messages.ts
+++ b/src/barcode-reader/messages.ts
@@ -5,7 +5,7 @@
  * and send a message when a barcode is successfully scanned.
  */
 
-import {BarcodeReaderConfig} from "./config";
+import type {BarcodeReaderConfig} from "./config";
 
 export enum BarcodeReaderMessageTypes {
     BarcodeScanned = "barcode-reader:BarcodeScanned",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "src/**/*.test.ts"
   ],
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Summary

Implements **Part A of variocube/drivers#16**: shared barcode-reader config schema, validation, and inbound `Configure` hook in `@variocube/driver-common`. Downstream consumers (barcode-serial driver, Cube-App-SDK) import what this adds. Vendor command translation is **out of scope** (lives in the driver).

Additive only — no breaking changes to `BarcodeScanned` / `sendBarcodeScanned`.

## New public API

- **`config.ts`**
  - `enum Symbology` — open v1 subset (EAN13/EAN8/UPCA/UPCE/Code128/Code39/QR/DataMatrix/PDF417/Aztec)
  - `interface BarcodeReaderConfig` — all groups optional: `symbologies`, `indicators`, `triggerTiming`, `outputFormatting`
  - `validateBarcodeConfig(config): ValidationResult` — pure, dependency-free, never throws. Single source of truth shared by SDK (pre-send) and driver (on-receive). Validates ranges/lengths/enums; unknown fields do **not** hard-fail (forward-compat).
- **`messages.ts`** — `BarcodeReaderMessageTypes.Configure` + `ConfigureBarcodeReader` message, added to the `BarcodeReaderMessage` union.
- **`driver.ts`** — `set onConfigure(handler)` hook on `BarcodeReaderDriver` (mirrors `LockingDriver.onOpenLock`).

All reachable from the package root.

## Validation rules

- brightness/volume: 0–100 (driver maps percentage onto device scale)
- timeouts / durations: non-negative, ≤ 1h sanity ceiling
- tone frequency: ≤ 20 kHz; inter-character delay: ≤ 1 min
- terminator: `CR` | `LF` | `CRLF` | `none`
- prefix/suffix ≤ 64 chars, groupSeparator ≤ 16 chars
- `led.enabled` / `beeper.enabled` / symbology values must be boolean

## Tests

24 table-driven tests over `validateBarcodeConfig` via `node:test` + `ts-node` (zero new deps). `*.test.ts` excluded from build output and the published tarball.

## Heads-up for consumers

`BarcodeReaderMessage` gained a member (`ConfigureBarcodeReader`). Consumers using an **exhaustive** `switch` (with a `never` guard) will get a compile error until they add the `Configure` case — expected for an additive inbound message.

## Out of scope

- Vendor command translation (driver ticket)
- Trigger mode (no command yet — deliberately no `mode` field)
- Controller / SDK changes (separate tickets)
