### PR TITLE
ci: publish to npm via trusted publisher (OIDC)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,25 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+    tags: ['*']
+  pull_request:
+permissions:
+  contents: read
+  id-token: write
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 18
-        registry-url: https://registry.npmjs.org
-        scope: '@variocube'
-    - run: npm ci
-      env:
-        NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    - run: npm run build
-    - if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        npm version ${GITHUB_REF#refs/*/} --no-git-tag-version
-        npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          scope: '@variocube'
+      - run: npm ci
+      - run: npm run build
+      - if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          npm version ${GITHUB_REF#refs/*/} --no-git-tag-version
+          npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Switches npm publishing from token-based auth to **trusted publishing** (OIDC), matching the setup in `@variocube/app-ui`.

| Before | After |
|---|---|
| `NODE_AUTH_TOKEN: secrets.NPM_TOKEN` | OIDC — no token |
| no `id-token` permission | `permissions: id-token: write` |
| `npm publish` | `npm publish --provenance --access public` |
| Node 18 (npm 10, no OIDC) | Node 24 (npm ≥ 11.5.1, required for trusted publishing) |
| `on: [push, pull_request]` | `main` + tags + PRs |

Also drops the redundant `NODE_AUTH_TOKEN` from `npm ci`.

## Required one-time setup on npmjs.com

This workflow alone is not enough — register the repo as a trusted publisher:

1. npmjs.com → `@variocube/driver-common` → **Settings → Trusted Publisher**
2. Add a **GitHub Actions** publisher: org `variocube`, repo `driver-common`, workflow `build.yml`, no environment
3. After that, the `NPM_TOKEN` repo secret can be deleted

Publishing still triggers by pushing a tag (e.g. `git tag 2.0.7 && git push --tags`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)