### PR TITLE
fix: make package tree-shakeable + add pure barcode-reader/config subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,21 @@
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./esm/index.d.ts",
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
+    "./barcode-reader/config": {
+      "types": "./esm/barcode-reader/config.d.ts",
+      "import": "./esm/barcode-reader/config.js",
+      "require": "./cjs/barcode-reader/config.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "scripts": {
     "build": "tsc && tsc -m esnext --outDir ./esm -d",
     "test": "node --test --require ts-node/register \"src/**/*.test.ts\""


### PR DESCRIPTION
## Summary

Makes `@variocube/driver-common` safe to consume from bundlers/browser targets that only need the pure barcode-reader config schema + validator, without dragging in the Node-only `ws`/`chalk` graph.

The root entry (`esm/index.js`) re-exports `logger` (→ `chalk`) and `common/client` (→ `ws`). So a consumer that only wants `validateBarcodeConfig` / `Symbology` — notably the **browser-targeted** `@variocube/cube-app-sdk` ([cube-app-sdk#30](https://github.com/variocube/cube-app-sdk/pull/30)) — still risked pulling `ws` (Node built-ins) and `chalk` into its bundle, since the package was neither marked tree-shakeable nor offered a narrow entry point.

## Changes (package.json only)

- **`"sideEffects": false`** — every module here is import-time side-effect-free, so this lets webpack/Vite tree-shake unused modules (e.g. drop `logger`/`client` when only the validator is used).
- **`exports` map** with a **`./barcode-reader/config`** subpath that maps straight to the dependency-free `config` module. Consumers can import the validator/schema without the `ws`/`chalk` graph entering the module graph at all — belt-and-suspenders for bundlers that don't tree-shake (dev mode, esbuild deps, etc.).
- Keeps the root `.` entry and a `./*` passthrough, so **existing root imports and any deep imports resolve exactly as before**.

## Verification

Built the package and resolved both entry points from Node:

| Entry | Resolves | `ws`/`chalk` pulled |
|-------|----------|---------------------|
| `@variocube/driver-common` (root) | ✅ unchanged | chalk, ws (as before) |
| `@variocube/driver-common/barcode-reader/config` (new) | ✅ | **none** |

The validator behaves identically through the subpath (`{ valid: false, errors: ['indicators.beeper.volume must be between 0 and 100'] }`).

## Base branch note

Targets **`feat/barcode-reader-config`**, not `main`: the barcode-reader config schema (`src/barcode-reader/config.ts`) lives only on this branch and is what the published `2.7.x` line — and therefore the SDK — actually consumes. `main` does not contain these files yet. The `exports` subpath references `config`, so it has to land on this lineage; a new patch release from here would let the SDK switch to the pure subpath import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)