### PR TITLE
Add optional unlockTime to locking OpenLock message

### DIFF
--- a/src/locking/messages.ts
+++ b/src/locking/messages.ts
@@ -104,6 +104,12 @@ export interface OpenLock {
 
     /** The id of the lock to open. */
     id: string;
+
+    /**
+     * Duration in milliseconds the lock should be held open. Only honored by drivers that support a configurable
+     * unlock time (currently kerong); ignored otherwise.
+     */
+    unlockTime?: number;
 }
 
 export type LockMessage =


### PR DESCRIPTION
Part of the admission rework (variocube/center#416).

Adds an optional `unlockTime?: number` (ms) to the `locking:OpenLock` message so the controller can pass a per-command hold duration to locking drivers. Additive and optional — non-kerong drivers ignore it.

Consumed by variocube/drivers#34 + variocube/driver-kerong#32. Controller already sends the field (variocube/controller#131).

Publish a new version (2.9.0) after merge; kerong drivers bump the dep (current range `^2.6.1` already admits it).